### PR TITLE
Fix zero limit account history call

### DIFF
--- a/hive/account.py
+++ b/hive/account.py
@@ -180,7 +180,7 @@ class Account(dict):
 
     def virtual_op_count(self):
         try:
-            last_item = self.hived.get_account_history(self.name, -1, 0)[0][0]
+            last_item = self.hived.get_account_history(self.name, -1, 1)[0][0]
         except IndexError:
             return 0
         else:


### PR DESCRIPTION
`virtual_op_count` uses an initial `get_account_history` call to get the account's operation height. For this, it was using a call with an `index` of `-1` (a special case meaning "starting from latest in reverse order"), and, for some reason, a `limit` of `0`, which before would apparently return a single result. Unfortunately, something must have changed recently, and this call now returns an empty array.

The solution was to change the `limit` from `0` to `1`.

I find it amusing that this pull request ends up effecting the smallest possible change: one bit of source code.